### PR TITLE
Fix back stack orientation change

### DIFF
--- a/backswipeview/src/main/java/me/jefferey/backswipeview/BackSwipeLayout.java
+++ b/backswipeview/src/main/java/me/jefferey/backswipeview/BackSwipeLayout.java
@@ -114,7 +114,6 @@ public class BackSwipeLayout extends ViewGroup {
             if (getChildCount() > 1) {
                 final View contentView = getChildAt(getChildCount() - 1);
                 final View incomingView = getChildAt(getChildCount() - 2);
-                int halfWidth = contentView.getWidth() / 2;
                 int incomingLeft = left - contentView.getWidth();
                 incomingView.layout((incomingLeft / 2), contentView.getTop(), left, contentView.getBottom());
             }
@@ -190,9 +189,8 @@ public class BackSwipeLayout extends ViewGroup {
     }
 
     public interface BackSwipeInterface {
-        public void onBackSwipeStarted();
-        //No longer needed because we move the incoming view in the layout
-        //public void onBackSwipeMove(int leftPosition);
-        public void onBackSwipeEnd(boolean didSwipeBack);
+        void onBackSwipeStarted();
+
+        void onBackSwipeEnd(boolean didSwipeBack);
     }
 }

--- a/backswipeview/src/main/java/me/jefferey/backswipeview/BackSwipeManager.java
+++ b/backswipeview/src/main/java/me/jefferey/backswipeview/BackSwipeManager.java
@@ -21,6 +21,7 @@ public class BackSwipeManager implements BackSwipeLayout.BackSwipeInterface, Fra
         mBackSwipeLayout.setBackSwipeEnabled(fragmentManager.getBackStackEntryCount() > 0);
         mContentViewId = mBackSwipeLayout.getId();
         mFragmentManager = fragmentManager;
+        hideBackStackFragments();
         mFragmentManager.addOnBackStackChangedListener(this);
     }
 
@@ -88,5 +89,21 @@ public class BackSwipeManager implements BackSwipeLayout.BackSwipeInterface, Fra
         } else {
             return null;
         }
+    }
+
+    /**
+     * When the fragment manager is restored from saved instance state hidden fragments are made visible
+     * again. This is called in the constructor to make sure that back stack fragments are now made
+     * visible.
+     */
+    private void hideBackStackFragments() {
+        int entryCount = mFragmentManager.getBackStackEntryCount();
+        FragmentTransaction ft =  mFragmentManager.beginTransaction();
+        for (int i = 0; i < entryCount; i++) {
+            FragmentManager.BackStackEntry entry = mFragmentManager.getBackStackEntryAt(i);
+            Fragment frag = mFragmentManager.findFragmentByTag(entry.getName());
+            ft.hide(frag);
+        }
+        ft.commit();
     }
 }


### PR DESCRIPTION
Resolves #1. It appears the fragment manager makes fragments that where hidden visible when recreating from saved instance state.  This change re hides the fragments when the BackSwipeManager is created.
